### PR TITLE
Change logout path

### DIFF
--- a/lib/omniauth/strategies/openid_connect.rb
+++ b/lib/omniauth/strategies/openid_connect.rb
@@ -310,7 +310,7 @@ module OmniAuth
       end
 
       def logout_path_pattern
-        @logout_path_pattern ||= %r{\A#{Regexp.quote(request_path)}(/logout)}
+        @logout_path_pattern ||= %r{\/(logout|sign_out)}
       end
 
       def id_token_callback_phase


### PR DESCRIPTION
`logout_path_pattern` shows a `logout` path but such a path doesn't exist in the gem, which I think it depends on the proper logout path of the client.